### PR TITLE
fix: sync copyright year to 2026 across all pages

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -556,7 +556,7 @@
                 </div>
 
                 <div class="footer-bottom">
-                    <p>&copy; 2024 QueueBos. All Rights Reserved.</p>
+                    <p>&copy; 2026 QueueBos. All Rights Reserved.</p>
                 </div>
             </div>
         </footer>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -608,7 +608,7 @@
                 </div>
 
                 <div class="footer-bottom">
-                    <p>&copy; 2024 QueueBos. All Rights Reserved.</p>
+                    <p>&copy; 2026 QueueBos. All Rights Reserved.</p>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
The copyright footer showed inconsistent years:
- index.html: 2026 (correct)
- privacy-policy.html: 2024 (outdated)
- terms-of-service.html: 2024 (outdated)