### PR TITLE
fix: add AOS typeof guard to privacy-policy.html and terms-of-service…

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -600,12 +600,14 @@
         <script src="assets/vendor/aos/aos.js"></script>
 
         <script>
-            AOS.init({
-                duration: 800,
-                easing: "ease-out-cubic",
-                once: true,
-                offset: 100,
-            });
+            if (typeof AOS !== "undefined") {
+                AOS.init({
+                    duration: 800,
+                    easing: "ease-out-cubic",
+                    once: true,
+                    offset: 100,
+                });
+            }
 
             window.addEventListener("scroll", function () {
                 const header = document.getElementById("header");

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -652,12 +652,14 @@
         <script src="assets/vendor/aos/aos.js"></script>
 
         <script>
-            AOS.init({
-                duration: 800,
-                easing: "ease-out-cubic",
-                once: true,
-                offset: 100,
-            });
+            if (typeof AOS !== "undefined") {
+                AOS.init({
+                    duration: 800,
+                    easing: "ease-out-cubic",
+                    once: true,
+                    offset: 100,
+                });
+            }
 
             window.addEventListener("scroll", function () {
                 const header = document.getElementById("header");


### PR DESCRIPTION
….html

Wrap AOS.init() calls in both pages with `if (typeof AOS !== "undefined")` to prevent ReferenceError if the AOS library fails to load. This matches the pattern already used in index.html via assets/js/main.js.