### PR TITLE
fix: remove dead #preloader CSS rule not referenced in HTML or JS

### DIFF
--- a/assets/css/skiplino-style.css
+++ b/assets/css/skiplino-style.css
@@ -441,8 +441,6 @@ img { max-width: 100%; height: auto; display: block; }
 .scroll-top.active { opacity: 1; visibility: visible; }
 .scroll-top:hover { background: var(--qb-green); color: #fff; transform: translateY(-3px); }
 
-#preloader { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: #fff; z-index: 9999; }
-
 /* =============================================================
    RESPONSIVE
    ============================================================= */


### PR DESCRIPTION
- Remove #preloader CSS from skiplino-style.css (was orphaned — no matching element in HTML and no JS code to manage it)
- JS preloader removal code was already cleaned up in earlier refactor