### PR TITLE
fix: replace scroll-top anchor with button to prevent hash in URL (#122)

### DIFF
--- a/assets/css/skiplino-style.css
+++ b/assets/css/skiplino-style.css
@@ -434,8 +434,9 @@ img { max-width: 100%; height: auto; display: block; }
    ============================================================= */
 .scroll-top {
   position: fixed; bottom: 30px; right: 30px; width: 44px; height: 44px;
-  background: var(--qb-primary); color: #fff; border-radius: 50%;
+  background: var(--qb-primary); color: #fff; border: none; border-radius: 50%;
   display: flex; align-items: center; justify-content: center; font-size: 1.25rem;
+  cursor: pointer;
   z-index: 998; opacity: 0; visibility: hidden; transition: var(--qb-transition); box-shadow: var(--qb-shadow-md);
 }
 .scroll-top.active { opacity: 1; visibility: visible; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -17,6 +17,13 @@ document.addEventListener("DOMContentLoaded", function () {
         if (scrollTopBtn) { scrollTopBtn.classList.toggle("active", window.scrollY > 400); }
     });
 
+    // Scroll-to-top button click handler
+    if (scrollTopBtn) {
+        scrollTopBtn.addEventListener("click", function () {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+        });
+    }
+
     // Mobile nav
     var mobileToggle = document.querySelector(".mobile-nav-toggle");
     var navMain = document.querySelector(".nav-main");

--- a/index.html
+++ b/index.html
@@ -751,7 +751,7 @@
             <span>Contact Us</span>
         </a>
 
-        <a href="#" class="scroll-top"><i class="bi bi-arrow-up-short"></i></a>
+        <button class="scroll-top" aria-label="Scroll to top"><i class="bi bi-arrow-up-short"></i></button>
 
         <!-- Vendor JS -->
         <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js" defer></script>


### PR DESCRIPTION
- Changed <a href='#' class='scroll-top'> to <button class='scroll-top'>
- Added dedicated click handler using window.scrollTo() for smooth scroll
- Added border: none and cursor: pointer to .scroll-top CSS for button styling