### PR TITLE
feat: add contact form fallback with mailto when external service fails

### DIFF
--- a/assets/css/skiplino-style.css
+++ b/assets/css/skiplino-style.css
@@ -393,6 +393,54 @@ img { max-width: 100%; height: auto; display: block; }
 .form-group input.is-invalid, .form-group textarea.is-invalid { border-color: #EF4444; }
 .form-group textarea { min-height: 120px; resize: vertical; }
 
+/* Form Fallback (shown when third-party form service is down) */
+.form-fallback {
+  display: none;
+  margin-top: 20px;
+  padding: 0;
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 0.35s ease, max-height 0.35s ease, padding 0.35s ease;
+}
+.form-fallback.active {
+  display: block;
+  opacity: 1;
+  max-height: 400px;
+  padding: 24px;
+  background: #FFF8E1;
+  border: 1px solid #F0C000;
+  border-radius: var(--qb-radius-md);
+}
+.form-fallback__content {
+  text-align: center;
+}
+.form-fallback__icon {
+  font-size: 2rem;
+  color: #D97706;
+  margin-bottom: 12px;
+  display: block;
+}
+.form-fallback__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--qb-gray-800);
+  margin-bottom: 8px;
+}
+.form-fallback__text {
+  font-size: 0.95rem;
+  color: var(--qb-text-secondary);
+  margin-bottom: 20px;
+}
+.form-fallback__text strong {
+  color: var(--qb-gray-900);
+}
+.form-fallback__mailto {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* =============================================================
    FOOTER
    ============================================================= */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -98,9 +98,69 @@ document.addEventListener("DOMContentLoaded", function () {
             });
             if (!valid) return;
             var fd = new FormData(this);
-            fetch(this.action, { method: this.method, body: fd })
-                .then(function () { alert("Thank you! Your message has been sent. We will contact you soon."); contactForm.reset(); })
-                .catch(function () { alert("Something went wrong. Please try again or contact us directly."); });
+            var submitBtn = contactForm.querySelector("button[type=\"submit\"]");
+            var originalBtnText = submitBtn.innerHTML;
+            submitBtn.disabled = true;
+            submitBtn.innerHTML = "Sending...";
+
+            fetch(contactForm.action, { method: contactForm.method, body: fd })
+                .then(function (response) {
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = originalBtnText;
+
+                    if (!response.ok) {
+                        // API returned an error (400, 500, etc.) — service is reachable but rejecting
+                        showFallback();
+                        return;
+                    }
+
+                    alert("Thank you! Your message has been sent. We will contact you soon.");
+                    contactForm.reset();
+                    removeFallback();
+                })
+                .catch(function () {
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = originalBtnText;
+                    showFallback();
+                });
         });
     }
+
+    // Fallback notice when third-party form service is unavailable
+    var fallbackEl = document.getElementById("formFallback");
+
+    window.showFallback = function () {
+        if (!fallbackEl) return;
+
+        // Read current form values to pre-fill the mailto link
+        var name    = (document.getElementById("name")    || {}).value || "";
+        var email   = (document.getElementById("email")   || {}).value || "";
+        var phone   = (document.getElementById("phone")   || {}).value || "";
+        var company = (document.getElementById("company") || {}).value || "";
+        var message = (document.getElementById("message") || {}).value || "";
+
+        var body =
+            "Name: " + name + "%0D%0A" +
+            "Email: " + email + "%0D%0A" +
+            "Phone: " + phone + "%0D%0A" +
+            "Company: " + company + "%0D%0A%0D%0A" +
+            message;
+
+        var mailtoHref = "mailto:hello@queuebos.com?subject=Request%20Demo%20-%20QueueBos&body=" + body;
+
+        // Build the mailto link and trigger it to open the user's email client
+        var mailtoLink = fallbackEl.querySelector(".form-fallback__mailto");
+        if (mailtoLink) {
+            mailtoLink.href = mailtoHref;
+        }
+        window.open(mailtoHref, "_self");
+
+        fallbackEl.classList.add("active");
+        fallbackEl.focus({ preventScroll: false });
+    };
+
+    window.removeFallback = function () {
+        if (!fallbackEl) return;
+        fallbackEl.classList.remove("active");
+    };
 });

--- a/index.html
+++ b/index.html
@@ -685,6 +685,16 @@
                                 </div>
                                 <button type="submit" class="btn-solid-green">Send Message <i class="bi bi-send-fill"></i></button>
                             </form>
+                            <div id="formFallback" class="form-fallback" role="alert" aria-live="assertive" tabindex="-1">
+                                <div class="form-fallback__content">
+                                    <i class="bi bi-exclamation-triangle-fill form-fallback__icon"></i>
+                                    <h4 class="form-fallback__title">Unable to send your message</h4>
+                                    <p class="form-fallback__text">The form service is currently unavailable. Please email us directly at <strong>hello@queuebos.com</strong> or use the link below.</p>
+                                    <a href="mailto:hello@queuebos.com?subject=Request%20Demo%20-%20QueueBos" class="btn-solid-green form-fallback__mailto">
+                                        <i class="bi bi-envelope-fill"></i> Email Us Directly
+                                    </a>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
When fetch to send.bah.my/phisoft fails (network error or non-2xx response), show a fallback notice with the email address and a mailto link pre-filled with the user's form data. Also opens the email client automatically.