### PR TITLE
redesign: remove cartoon star ratings from trust bar (#147)

### DIFF
--- a/assets/css/skiplino-style.css
+++ b/assets/css/skiplino-style.css
@@ -161,7 +161,6 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .trust-card:hover { box-shadow: var(--qb-shadow-md); transform: translateY(-2px); }
 .trust-card__score { font-size: 2.5rem; font-weight: 800; color: var(--qb-primary); display: block; margin-bottom: 8px; }
-.trust-card__stars { color: #F59E0B; font-size: 1.125rem; margin-bottom: 4px; }
 .trust-card__source { font-size: 0.85rem; color: var(--qb-text-muted); }
 
 /* =============================================================

--- a/index.html
+++ b/index.html
@@ -155,24 +155,15 @@
                     <div class="trust-cards">
                         <div class="trust-card">
                             <span class="trust-card__score">500+</span>
-                            <div class="trust-card__meta">
-                                <div class="trust-card__stars">★★★★★</div>
-                                <span class="trust-card__source">Businesses Using QueueBos</span>
-                            </div>
+                            <span class="trust-card__source">Businesses Using QueueBos</span>
                         </div>
                         <div class="trust-card">
                             <span class="trust-card__score">60%</span>
-                            <div class="trust-card__meta">
-                                <div class="trust-card__stars">★★★★★</div>
-                                <span class="trust-card__source">Average Wait Time Reduction</span>
-                            </div>
+                            <span class="trust-card__source">Average Wait Time Reduction</span>
                         </div>
                         <div class="trust-card">
                             <span class="trust-card__score">15min</span>
-                            <div class="trust-card__meta">
-                                <div class="trust-card__stars">★★★★★</div>
-                                <span class="trust-card__source">Setup Time — Plug in & Go</span>
-                            </div>
+                            <span class="trust-card__source">Setup Time — Plug in & Go</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Removed ★★★★★ star divs and .trust-card__meta wrapper from all 3 trust cards. Removed .trust-card__stars CSS rule. Trust cards now display clean bold numbers with professional descriptive labels for enterprise credibility.