### PR TITLE
content: merge redundant Architecture and Hardware sections into sing…

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
                     <a href="#how-it-works" class="nav-link">How It Works</a>
                     <a href="#features" class="nav-link">Features</a>
                     <a href="#pricing" class="nav-link">Pricing</a>
-                    <a href="#architecture" class="nav-link">Architecture</a>
+                    <a href="#whats-included" class="nav-link">What's Included</a>
                     <a href="#comparison" class="nav-link">Comparison</a>
                     <a href="#faq" class="nav-link">FAQ</a>
                 </nav>
@@ -283,19 +283,19 @@
                 </div>
             </section>
 
-            <!-- ======= What You Need Section ======= -->
-            <section class="arch-section" id="architecture" aria-labelledby="arch-heading">
+            <!-- ======= What's Included Section ======= -->
+            <section class="arch-section" id="whats-included" aria-labelledby="arch-heading">
                 <div class="container">
                     <div class="section-header">
-                        <p class="section-eyebrow">What You Need</p>
-                        <h2 id="arch-heading" class="section-heading-lg">One Tablet.<br />Everything Built In.</h2>
+                        <p class="section-eyebrow">What's Included</p>
+                        <h2 id="arch-heading" class="section-heading-lg">Unbox Your Queue.<br />Everything's in the Box.</h2>
                     </div>
                     <div class="arch-layout" data-aos="fade-up">
                         <div class="arch-hub">
                             <div class="arch-hub__card">
                                 <i class="bi bi-tablet"></i>
-                                <span>Imin Android Tablet</span>
-                                <small>Everything runs on this one device</small>
+                                <span>1 × Imin Android Tablet</span>
+                                <small>Kiosk + Server + Printer — all built in</small>
                             </div>
                         </div>
                         <div class="arch-nodes">
@@ -306,32 +306,32 @@
                             </div>
                             <div class="arch-node-card">
                                 <i class="bi bi-printer"></i>
-                                <span>Printer Built-In</span>
+                                <span>Built-in Thermal Printer</span>
                                 <small>Instant ticket printing</small>
                             </div>
                             <div class="arch-node-card">
                                 <i class="bi bi-tv"></i>
-                                <span>TV Screen</span>
-                                <small>Shows current queue</small>
+                                <span>TV Display</span>
+                                <small>Any existing TV works</small>
                             </div>
                             <div class="arch-node-card">
                                 <i class="bi bi-phone"></i>
-                                <span>Staff Phones</span>
-                                <small>Call next number</small>
+                                <span>Staff Smartphones</span>
+                                <small>No app install needed</small>
                             </div>
                             <div class="arch-node-card">
                                 <i class="bi bi-shield-check"></i>
-                                <span>Your Data Safe</span>
+                                <span>Your Data, Local</span>
                                 <small>Stored on your tablet</small>
                             </div>
                             <div class="arch-node-card">
                                 <i class="bi bi-wifi"></i>
-                                <span>Existing WiFi</span>
-                                <small>No internet needed</small>
+                                <span>Your Existing WiFi</span>
+                                <small>No internet required</small>
                             </div>
                         </div>
                     </div>
-                    <p class="arch-caption" data-aos="fade-up" data-aos-delay="100">No separate server. No subscription fees. No cloud setup. Everything works on your tablet in 15 minutes.</p>
+                    <p class="arch-caption" data-aos="fade-up" data-aos-delay="100">No separate server. No subscription fees. No cloud setup. Unbox, plug in, and you're running in 15 minutes.</p>
                 </div>
             </section>
 
@@ -577,43 +577,6 @@
                                 <p class="industry-card__desc">Manage public queues and enhance customer experience across mail and courier counters.</p>
                             </div>
                             <div class="industry-card__icon"><i class="bi bi-envelope"></i></div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <!-- ======= Hardware Section ======= -->
-            <section class="hardware-section" id="hardware" aria-labelledby="hardware-heading">
-                <div class="container">
-                    <div class="section-header">
-                        <p class="section-eyebrow">Hardware</p>
-                        <h2 id="hardware-heading" class="section-heading-lg">All You Need Is<br />One Tablet</h2>
-                    </div>
-                    <div class="hardware-grid" data-aos="fade-up">
-                        <div class="hardware-card hardware-card--main">
-                            <div class="hardware-card__icon"><i class="bi bi-tablet"></i></div>
-                            <h3>1 × Imin Android Tablet</h3>
-                            <p class="hardware-card__role">Kiosk + Server + Printer (all-in-one)</p>
-                            <p class="hardware-card__cost">~RM 2,500–3,500</p>
-                            <span class="hardware-card__badge">PRIMARY</span>
-                        </div>
-                        <div class="hardware-card">
-                            <div class="hardware-card__icon"><i class="bi bi-tv"></i></div>
-                            <h3>1 × TV Screen</h3>
-                            <p class="hardware-card__role">Waiting area display</p>
-                            <p class="hardware-card__cost">Any existing TV</p>
-                        </div>
-                        <div class="hardware-card">
-                            <div class="hardware-card__icon"><i class="bi bi-phone"></i></div>
-                            <h3>Staff Smartphones</h3>
-                            <p class="hardware-card__role">Counter controls</p>
-                            <p class="hardware-card__cost">Staff bring their own</p>
-                        </div>
-                        <div class="hardware-card">
-                            <div class="hardware-card__icon"><i class="bi bi-wifi"></i></div>
-                            <h3>Local WiFi Network</h3>
-                            <p class="hardware-card__role">Connectivity between devices</p>
-                            <p class="hardware-card__cost">Existing infrastructure</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
…le What's Included (#149)

Merged the overlapping 'Architecture' and 'Hardware' sections into one concise 'What's Included' section placed right after Features.

Changes:
- Renamed #architecture -> #whats-included with updated id and nav link
- Removed redundant .hardware-section entirely
- Updated heading: 'Unbox Your Queue. Everything's in the Box.'
- Refined node card labels for clarity
- Updated caption: 'Unbox, plug in, and you're running in 15 minutes.'